### PR TITLE
updated padding on model unit name drag child to not visually change …

### DIFF
--- a/lib/screens/unitSelector/selected_unit_model_cell.dart
+++ b/lib/screens/unitSelector/selected_unit_model_cell.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:gearforce/screens/unitSelector/unit_selection_text_Cell.dart';
+
+class SelectedUnitModelCell extends StatelessWidget {
+  const SelectedUnitModelCell({
+    Key? key,
+    required this.text,
+    this.hasBorder = false,
+    this.borderSize = 0,
+  })  : assert(borderSize <= 5),
+        super(key: key);
+
+  final String text;
+  final bool hasBorder;
+  final double borderSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final double iconPadding = this.hasBorder
+        ? this.borderSize > 2
+            ? 0
+            : 2 - this.borderSize
+        : 2;
+    return Row(
+      children: [
+        Padding(
+          padding: EdgeInsets.fromLTRB(
+              iconPadding,
+              iconPadding,
+              0,
+              iconPadding),
+          child: Icon(Icons.drag_indicator),
+        ),
+        UnitSelectionTextCell.content(
+          this.text,
+          maxLines: 1,
+          alignment: Alignment.centerLeft,
+          padding: this.hasBorder
+              ? EdgeInsets.fromLTRB(
+                  5, 5 - this.borderSize, 5, 5 - this.borderSize)
+              : const EdgeInsets.all(5),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/unitSelector/selected_unit_model_cell.dart
+++ b/lib/screens/unitSelector/selected_unit_model_cell.dart
@@ -25,10 +25,11 @@ class SelectedUnitModelCell extends StatelessWidget {
       children: [
         Padding(
           padding: EdgeInsets.fromLTRB(
-              iconPadding,
-              iconPadding,
-              0,
-              iconPadding),
+            iconPadding,
+            iconPadding,
+            0,
+            iconPadding,
+          ),
           child: Icon(Icons.drag_indicator),
         ),
         UnitSelectionTextCell.content(

--- a/lib/screens/unitSelector/unit_selection.dart
+++ b/lib/screens/unitSelector/unit_selection.dart
@@ -5,6 +5,7 @@ import 'package:gearforce/models/roster/roster.dart';
 import 'package:gearforce/models/unit/role.dart';
 import 'package:gearforce/models/unit/unit_core.dart';
 import 'package:gearforce/screens/unitSelector/selected_unit_feedback.dart';
+import 'package:gearforce/screens/unitSelector/selected_unit_model_cell.dart';
 import 'package:gearforce/screens/unitSelector/selection_filters.dart';
 import 'package:gearforce/screens/unitSelector/unit_selection_text_Cell.dart';
 import 'package:provider/provider.dart';
@@ -146,35 +147,24 @@ class SelectionList extends StatelessWidget {
     return DataRow(cells: [
       DataCell(
         Draggable<UnitCore>(
-          childWhenDragging: Row(
-            children: [
-              Icon(Icons.drag_indicator),
-              Expanded(
-                child: UnitSelectionTextCell.childWhenDragging(
-                  '${uc.name}',
-                  border: Border.all(
-                    color: Colors.green,
-                    width: 2.0,
-                  ),
+          childWhenDragging: Container(
+              decoration: BoxDecoration(
+                color: null,
+                border: Border.all(
+                  color: Colors.green,
+                  width: 2.0,
                 ),
               ),
-            ],
-          ),
+              child: SelectedUnitModelCell(
+                text: uc.name,
+                hasBorder: true,
+                borderSize: 2.0,
+              )),
           feedback: SelectedUnitFeedback(
             uc: uc,
           ),
           data: uc,
-          child: Row(
-            children: [
-              Icon(Icons.drag_indicator),
-              UnitSelectionTextCell.content(
-                '${uc.name}',
-                maxLines: 1,
-                alignment: Alignment.centerLeft,
-                padding: const EdgeInsets.fromLTRB(3, 5, 5, 5),
-              ),
-            ],
-          ),
+          child: SelectedUnitModelCell(text: uc.name),
         ),
       ),
       DataCell(UnitSelectionTextCell.content('${uc.tv}')),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.12.1
+version: 0.12.2
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
…when selected

moved the creation of the unit selection model name to be a custom widget