### PR TITLE
units types that cannot be vet can no longer select vet status

### DIFF
--- a/lib/models/mods/veteranUpgrades/veteran_modification.dart
+++ b/lib/models/mods/veteranUpgrades/veteran_modification.dart
@@ -48,10 +48,18 @@ class VeteranModification extends BaseModification {
         id: veteranId,
         requirementCheck:
             (RuleSet? rs, UnitRoster? ur, CombatGroup? cg, Unit u) {
+          assert(cg != null);
           if (u.hasMod(veteranId)) {
             return false;
           }
-          assert(cg != null);
+
+          if (u.type == ModelType.Drone ||
+              u.type == ModelType.Terrain ||
+              u.type == ModelType.AreaTerrain ||
+              u.type == ModelType.AirstrikeCounter ||
+              u.traits.any((t) => t.name == "Conscript")) {
+            return false;
+          }
           return cg!.isVeteran && !u.traits.any((trait) => trait.name == 'Vet');
         })
       ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
@@ -420,7 +428,7 @@ class VeteranModification extends BaseModification {
   */
   factory VeteranModification.improvedGunnery(Unit u) {
     final gunnery = u.gunnery;
-    var modCost = u.actions! * 2;
+    var modCost = u.actions != null ? u.actions! * 2 : 0;
 
     return VeteranModification(
         name: 'Improved Gunnery',

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -15,7 +15,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '0.39.0';
+const String _version = '0.39.1';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.39.0
+version: 0.39.1
 
 environment:
   sdk: ">=2.17.3 <3.0.0"


### PR DESCRIPTION
fixed a null error with improved gunnery when viewing possible upgrades for a model with no actions