### PR TITLE
Removing role types that had been removed from the game

### DIFF
--- a/lib/data/data.dart
+++ b/lib/data/data.dart
@@ -43,9 +43,11 @@ class Data {
   List<UnitCore> unitList(
     FactionType faction, {
     List<RoleType?>? role,
-    List<String>? filters,
+    List<String>? characterFilter,
+    bool Function(UnitCore)? filter,
     bool includeTerrain = true,
     bool includeAirstrikeTokens = true,
+    bool includeUniversal = true,
   }) {
     List<Frame>? factionUnits = _factionFrames[faction]!.toList();
 
@@ -55,26 +57,30 @@ class Data {
       case FactionType.NuCoal:
       case FactionType.PeaceRiver:
       case FactionType.BlackTalon:
-        var uniList = _factionFrames[FactionType.Universal_TerraNova];
-        if (uniList != null) {
-          factionUnits.addAll(uniList.toList());
-        }
-        var fullUniList = _factionFrames[FactionType.Universal];
-        if (fullUniList != null) {
-          factionUnits.addAll(fullUniList.toList());
+        if (includeUniversal) {
+          var uniList = _factionFrames[FactionType.Universal_TerraNova];
+          if (uniList != null) {
+            factionUnits.addAll(uniList.toList());
+          }
+          var fullUniList = _factionFrames[FactionType.Universal];
+          if (fullUniList != null) {
+            factionUnits.addAll(fullUniList.toList());
+          }
         }
         break;
       case FactionType.CEF:
       case FactionType.Caprice:
       case FactionType.Utopia:
       case FactionType.Eden:
-        var uniList = _factionFrames[FactionType.Universal_Non_TerraNova];
-        if (uniList != null) {
-          factionUnits.addAll(uniList.toList());
-        }
-        var fullUniList = _factionFrames[FactionType.Universal];
-        if (fullUniList != null) {
-          factionUnits.addAll(fullUniList.toList());
+        if (includeUniversal) {
+          var uniList = _factionFrames[FactionType.Universal_Non_TerraNova];
+          if (uniList != null) {
+            factionUnits.addAll(uniList.toList());
+          }
+          var fullUniList = _factionFrames[FactionType.Universal];
+          if (fullUniList != null) {
+            factionUnits.addAll(fullUniList.toList());
+          }
         }
         break;
       case FactionType.Universal:
@@ -103,24 +109,25 @@ class Data {
       }
     }
 
-    List<UnitCore> ulist = [];
-
+    List<UnitCore> results = [];
     factionUnits.forEach((f) {
-      ulist.addAll(f.variants);
+      filter != null
+          ? results.addAll(f.variants.where(filter))
+          : results.addAll(f.variants);
     });
 
-    var results = (role == null || role.isEmpty)
-        ? ulist
-        : ulist.where((element) {
-            if (element.role != null) {
-              return element.role!.includesRole(role);
-            }
-            return false;
-          }).toList();
+    if (role != null && role.isNotEmpty) {
+      results = results.where((uc) {
+        if (uc.role != null) {
+          return uc.role!.includesRole(role);
+        }
+        return false;
+      }).toList();
+    }
 
-    return filters == null
+    return characterFilter == null
         ? results
-        : results.where((element) => element.contains(filters)).toList();
+        : results.where((uc) => uc.contains(characterFilter)).toList();
   }
 
   /// This function loads all needed data resources.

--- a/lib/data/data.dart
+++ b/lib/data/data.dart
@@ -110,10 +110,10 @@ class Data {
     }
 
     List<UnitCore> results = [];
-    factionUnits.forEach((f) {
+    factionUnits.forEach((frame) {
       filter != null
-          ? results.addAll(f.variants.where(filter))
-          : results.addAll(f.variants);
+          ? results.addAll(frame.variants.where(filter))
+          : results.addAll(frame.variants);
     });
 
     if (role != null && role.isNotEmpty) {

--- a/lib/models/rules/black_talons.dart
+++ b/lib/models/rules/black_talons.dart
@@ -14,7 +14,8 @@ class BlackTalons extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.BlackTalon, role: role, filters: filters);
+    return data.unitList(FactionType.BlackTalon,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/caprice.dart
+++ b/lib/models/rules/caprice.dart
@@ -15,7 +15,8 @@ class Caprice extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.Caprice, role: role, filters: filters);
+    return data.unitList(FactionType.Caprice,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/cef.dart
+++ b/lib/models/rules/cef.dart
@@ -15,7 +15,7 @@ class CEF extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.CEF, role: role, filters: filters);
+    return data.unitList(FactionType.CEF, role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/eden.dart
+++ b/lib/models/rules/eden.dart
@@ -15,7 +15,8 @@ class Eden extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.Eden, role: role, filters: filters);
+    return data.unitList(FactionType.Eden,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/north.dart
+++ b/lib/models/rules/north.dart
@@ -15,7 +15,8 @@ class North extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.North, role: role, filters: filters);
+    return data.unitList(FactionType.North,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/nucoal.dart
+++ b/lib/models/rules/nucoal.dart
@@ -15,7 +15,8 @@ class Nucoal extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.NuCoal, role: role, filters: filters);
+    return data.unitList(FactionType.NuCoal,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/peace_river.dart
+++ b/lib/models/rules/peace_river.dart
@@ -32,7 +32,8 @@ class PeaceRiver extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.PeaceRiver, role: role, filters: filters);
+    return data.unitList(FactionType.PeaceRiver,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/rule_set.dart
+++ b/lib/models/rules/rule_set.dart
@@ -85,7 +85,7 @@ abstract class RuleSet {
   }
 
   bool _isAlwaysAllowedRole(Roles? r) {
-    return r == null || r.includesRole([RoleType.Upgrade]);
+    return r == null;
   }
 
   // Ensure the target Roletype is within the Roles

--- a/lib/models/rules/south.dart
+++ b/lib/models/rules/south.dart
@@ -15,7 +15,8 @@ class South extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.South, role: role, filters: filters);
+    return data.unitList(FactionType.South,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/rules/utopia.dart
+++ b/lib/models/rules/utopia.dart
@@ -15,7 +15,8 @@ class Utopia extends RuleSet {
     List<RoleType?>? role,
     List<String>? filters,
   }) {
-    return data.unitList(FactionType.Utopia, role: role, filters: filters);
+    return data.unitList(FactionType.Utopia,
+        role: role, characterFilter: filters);
   }
 
   @override

--- a/lib/models/unit/role.dart
+++ b/lib/models/unit/role.dart
@@ -26,14 +26,8 @@ RoleType convertRoleType(String role) {
       return RoleType.RC;
     case "SO":
       return RoleType.SO;
-    case "EG":
-      return RoleType.EG;
-    case "AS":
-      return RoleType.AS;
     case "FT":
       return RoleType.FT;
-    case 'UPGRADE':
-      return RoleType.Upgrade;
   }
 
   throw new FormatException("Unknown role type", role);
@@ -68,4 +62,4 @@ class Roles {
   }
 }
 
-enum RoleType { GP, SK, FS, RC, SO, EG, AS, FT, Upgrade }
+enum RoleType { GP, SK, FS, RC, SO, FT }

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -15,7 +15,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '0.39.1';
+const String _version = '0.39.2';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';

--- a/lib/screens/unitSelector/unit_selection.dart
+++ b/lib/screens/unitSelector/unit_selection.dart
@@ -83,11 +83,8 @@ class SelectionList extends StatelessWidget {
     );
   }
 
-  Widget _buildTable(RuleSet? ruleSet) {
-    if (ruleSet == null) {
-      return Container();
-    }
-    var d = ruleSet.availableUnits(
+  Widget _buildTable(RuleSet ruleSet) {
+    final d = ruleSet.availableUnits(
       role: this
           .roleFilters
           .entries
@@ -98,7 +95,7 @@ class SelectionList extends StatelessWidget {
           this.filter?.split(',').where((element) => element != '').toList(),
     );
 
-    var table = DataTable(
+    final table = DataTable(
       columns: _createTableColumns(),
       rows: d.map((uc) => _createTableRow(uc)).toList(),
       columnSpacing: 2.0,
@@ -161,7 +158,7 @@ class SelectionList extends StatelessWidget {
         UnitSelectionTextCell.content(
           uc.role != null ? '${uc.role!.roles.join(', ')}' : 'N/A',
           maxLines: 2,
-          softWrap: false,
+          softWrap: true,
         ),
       ),
       DataCell(UnitSelectionTextCell.content(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.39.1
+version: 0.39.2
 
 environment:
   sdk: ">=2.17.3 <3.0.0"

--- a/test/data/data_test.dart
+++ b/test/data/data_test.dart
@@ -90,25 +90,35 @@ void main() {
   test('test unitlist with name filter', () async {
     final data = Data();
     await data.load();
-    expect(data.unitList(FactionType.PeaceRiver, filters: ['warrior']).length,
+    expect(
+        data.unitList(FactionType.PeaceRiver,
+            characterFilter: ['warrior']).length,
         greaterThan(0),
         reason: 'check for at least 1 result');
-    expect(data.unitList(FactionType.PeaceRiver, filters: ['warrior']).length,
+    expect(
+        data.unitList(FactionType.PeaceRiver,
+            characterFilter: ['warrior']).length,
         lessThan(data.unitList(FactionType.PeaceRiver).length),
         reason: 'filtered list should be smaller');
-    print(data.unitList(FactionType.PeaceRiver, filters: ['warrior']).length);
+    print(data
+        .unitList(FactionType.PeaceRiver, characterFilter: ['warrior']).length);
   });
 
   test('test unitlist with trait filter', () async {
     final data = Data();
     await data.load();
-    expect(data.unitList(FactionType.PeaceRiver, filters: ['airdrop']).length,
+    expect(
+        data.unitList(FactionType.PeaceRiver,
+            characterFilter: ['airdrop']).length,
         greaterThan(0),
         reason: 'check for at least 1 result');
-    expect(data.unitList(FactionType.PeaceRiver, filters: ['airdrop']).length,
+    expect(
+        data.unitList(FactionType.PeaceRiver,
+            characterFilter: ['airdrop']).length,
         lessThan(data.unitList(FactionType.PeaceRiver).length),
         reason: 'filtered list should be smaller');
-    print(data.unitList(FactionType.PeaceRiver, filters: ['airdrop']).length);
+    print(data
+        .unitList(FactionType.PeaceRiver, characterFilter: ['airdrop']).length);
   });
 
   test('test unitlist with trait filter and name filter', () async {
@@ -116,15 +126,15 @@ void main() {
     await data.load();
     expect(
         data.unitList(FactionType.PeaceRiver,
-            filters: ['airdrop', 'warrior']).length,
+            characterFilter: ['airdrop', 'warrior']).length,
         greaterThan(0),
         reason: 'check for at least 1 result');
     expect(
         data.unitList(FactionType.PeaceRiver,
-            filters: ['airdrop', 'warrior']).length,
+            characterFilter: ['airdrop', 'warrior']).length,
         lessThan(data.unitList(FactionType.PeaceRiver).length),
         reason: 'filtered list should be smaller');
     print(data.unitList(FactionType.PeaceRiver,
-        filters: ['airdrop', 'warrior']).length);
+        characterFilter: ['airdrop', 'warrior']).length);
   });
 }

--- a/test/models/combatGroups/group_test.dart
+++ b/test/models/combatGroups/group_test.dart
@@ -18,20 +18,6 @@ void main() {
     expect(g.totalTV(), equals(0), reason: 'check default total tv');
   });
 
-  test('set role on default Group', () {
-    var g = Group(GroupType.Primary);
-    expect(g.role(), equals(RoleType.GP), reason: 'role');
-    g.changeRole(RoleType.AS);
-    expect(g.role(), equals(RoleType.AS), reason: 'check group name');
-  });
-
-  test('change Group role', () {
-    var g = Group(GroupType.Primary, role: RoleType.GP);
-    expect(g.role(), RoleType.GP, reason: 'initial role');
-    g.changeRole(RoleType.AS);
-    expect(g.role(), RoleType.AS, reason: 'updated role');
-  });
-
   test('create Group with role and units being reset', () {
     var g = Group(GroupType.Primary, role: RoleType.GP)
       ..addUnit(UnitCore.test());


### PR DESCRIPTION
Removed the AG, AS and UPGRADE role types since they were removed from the rules.
Cleaned up and added a new filter option for the unitList function to better filter models.