### PR TITLE
Implemented NuCoal PAK rules

### DIFF
--- a/lib/models/factions/faction.dart
+++ b/lib/models/factions/faction.dart
@@ -72,7 +72,7 @@ class Faction {
     final rulesets = [
       NuCoal(data, name: _emptySubFactionName),
       NuCoal.NSDF(data),
-      // NuCoal.PAK(data),
+      NuCoal.PAK(data),
       // NuCoal.HAPF(data),
       // NuCoal.KADA(data),
       // NuCoal.TH(data),

--- a/lib/models/mods/factionUpgrades/faction_mod.dart
+++ b/lib/models/mods/factionUpgrades/faction_mod.dart
@@ -1,5 +1,6 @@
 import 'package:gearforce/models/mods/base_modification.dart';
 import 'package:gearforce/models/mods/factionUpgrades/north.dart';
+import 'package:gearforce/models/mods/factionUpgrades/nucoal.dart';
 import 'package:gearforce/models/mods/factionUpgrades/peace_river.dart';
 import 'package:gearforce/models/mods/factionUpgrades/south.dart';
 import 'package:gearforce/models/roster/roster.dart';
@@ -67,6 +68,14 @@ FactionModification? factionModFromId(String id, UnitRoster ur, Unit u) {
       return SouthernFactionMods.samuraiSpirit(u);
     case metsukeId:
       return SouthernFactionMods.metsuke(u);
+
+    // NuCoal Faction mods
+    case hoverTankCommanderId:
+      return NuCoalFactionMods.hoverTankCommander();
+    case tankJockeysId:
+      return NuCoalFactionMods.tankJockeys();
+    case somethingToProveId:
+      return NuCoalFactionMods.somethingToProve();
   }
   return null;
 }

--- a/lib/models/mods/factionUpgrades/nucoal.dart
+++ b/lib/models/mods/factionUpgrades/nucoal.dart
@@ -1,0 +1,152 @@
+import 'package:gearforce/models/combatGroups/combat_group.dart';
+import 'package:gearforce/models/mods/base_modification.dart';
+import 'package:gearforce/models/mods/factionUpgrades/faction_mod.dart';
+import 'package:gearforce/models/mods/mods.dart';
+import 'package:gearforce/models/roster/roster.dart';
+import 'package:gearforce/models/rules/nucoal/pak.dart' as pak;
+import 'package:gearforce/models/rules/rule_set.dart';
+import 'package:gearforce/models/traits/trait.dart';
+import 'package:gearforce/models/unit/command.dart';
+import 'package:gearforce/models/unit/model_type.dart';
+import 'package:gearforce/models/unit/unit.dart';
+import 'package:gearforce/models/unit/unit_attribute.dart';
+
+const _factionModIdBase = 'mod::faction::nucoal';
+const hoverTankCommanderId = '$_factionModIdBase::10';
+const tankJockeysId = '$_factionModIdBase::20';
+const somethingToProveId = '$_factionModIdBase::30';
+
+class NuCoalFactionMods extends FactionModification {
+  NuCoalFactionMods({
+    required super.name,
+    required super.id,
+    required super.requirementCheck,
+    super.options,
+    super.onAdd,
+    super.onRemove,
+  }) : super();
+
+  /*
+    Hover Tank Commander: Any commander that is in a vehicle type model may
+    improve its EW skill by one, to a maximum of 3+, for 1 TV each.
+  */
+  factory NuCoalFactionMods.hoverTankCommander() {
+    final RequirementCheck reqCheck =
+        (RuleSet? rs, UnitRoster? ur, CombatGroup? cg, Unit u) {
+      assert(cg != null);
+      assert(rs != null);
+
+      if (u.commandLevel == CommandLevel.none) {
+        return false;
+      }
+
+      if (u.type != ModelType.Vehicle) {
+        return false;
+      }
+
+      if (rs == null || !rs.isRuleEnabled(pak.ruleHoverTankCommander.id)) {
+        return false;
+      }
+
+      return true;
+    };
+
+    final fm = NuCoalFactionMods(
+      name: 'Hover Tank Commander',
+      requirementCheck: reqCheck,
+      id: hoverTankCommanderId,
+    );
+    fm.addMod<int>(UnitAttribute.tv, createSimpleIntMod(1),
+        description: 'TV: +1');
+    fm.addMod<int>(UnitAttribute.ew, createSimpleIntMod(-1, min: 3),
+        description: 'Hover Tank Commander: Any commander that is in a' +
+            ' vehicle type model may improve its EW skill by one, to a' +
+            ' maximum of 3+, for 1 TV each.');
+
+    return fm;
+  }
+
+  /*
+    Tank Jockeys: Vehicles with the Agile trait may purchase the following 
+    ability for 1 TV each: Ignore the movement penalty for traveling through
+    difficult terrain.
+  */
+  factory NuCoalFactionMods.tankJockeys() {
+    final RequirementCheck reqCheck =
+        (RuleSet? rs, UnitRoster? ur, CombatGroup? cg, Unit u) {
+      assert(cg != null);
+      assert(rs != null);
+
+      if (u.type != ModelType.Vehicle) {
+        return false;
+      }
+
+      if (!u.traits.any((t) => t.name == Trait.Agile().name)) {
+        return false;
+      }
+
+      if (rs == null || !rs.isRuleEnabled(pak.ruleTankJockeys.id)) {
+        return false;
+      }
+
+      return true;
+    };
+
+    final fm = NuCoalFactionMods(
+      name: 'Tank Jockeys',
+      requirementCheck: reqCheck,
+      id: tankJockeysId,
+    );
+    fm.addMod<int>(UnitAttribute.tv, createSimpleIntMod(1),
+        description: 'TV: +1');
+
+    const tankJockeyBenefit =
+        'Ignore the movement penalty for traveling through difficult terrain.';
+    fm.addMod<List<String>>(
+        UnitAttribute.special, createAddStringToList(tankJockeyBenefit),
+        description: 'Vehicles with the Agile trait may' +
+            ' purchase the following ability for 1 TV each: Ignore the' +
+            ' movement penalty for traveling through difficult terrain.');
+
+    return fm;
+  }
+
+  /*
+    Something to Prove: GREL infantry may increase their GU skill by one for 1
+     TV each.
+  */
+  factory NuCoalFactionMods.somethingToProve() {
+    final RequirementCheck reqCheck =
+        (RuleSet? rs, UnitRoster? ur, CombatGroup? cg, Unit u) {
+      assert(cg != null);
+      assert(rs != null);
+
+      if (u.type != ModelType.Infantry) {
+        return false;
+      }
+
+      if (!u.core.frame.contains('GREL')) {
+        return false;
+      }
+
+      if (rs == null || !rs.isRuleEnabled(pak.ruleSomethingToProve.id)) {
+        return false;
+      }
+
+      return true;
+    };
+
+    final fm = NuCoalFactionMods(
+      name: 'Something To Prove',
+      requirementCheck: reqCheck,
+      id: somethingToProveId,
+    );
+    fm.addMod<int>(UnitAttribute.tv, createSimpleIntMod(1),
+        description: 'TV: +1');
+
+    fm.addMod(UnitAttribute.gunnery, createSimpleIntMod(-1),
+        description: 'GREL infantry may increase their GU skill by one');
+
+    return fm;
+  }
+}

--- a/lib/models/mods/mods.dart
+++ b/lib/models/mods/mods.dart
@@ -1,11 +1,15 @@
+import 'dart:math';
+
 import 'package:gearforce/models/traits/trait.dart';
 import 'package:gearforce/models/unit/movement.dart';
 import 'package:gearforce/models/unit/role.dart';
 import 'package:gearforce/models/weapons/weapon.dart';
 
-int Function(int) createSimpleIntMod(int change) {
+int Function(int) createSimpleIntMod(int change, {int? min}) {
   return (value) {
-    return value + change;
+    final newValue = value + change;
+
+    return min != null ? max(min, newValue) : newValue;
   };
 }
 

--- a/lib/models/rules/black_talons/black_talons.dart
+++ b/lib/models/rules/black_talons/black_talons.dart
@@ -41,8 +41,8 @@ class BlackTalons extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.BlackTalon),

--- a/lib/models/rules/caprice/caprice.dart
+++ b/lib/models/rules/caprice/caprice.dart
@@ -45,8 +45,8 @@ class Caprice extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.Caprice),

--- a/lib/models/rules/cef/cef.dart
+++ b/lib/models/rules/cef/cef.dart
@@ -45,8 +45,8 @@ class CEF extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.CEF),

--- a/lib/models/rules/eden/eden.dart
+++ b/lib/models/rules/eden/eden.dart
@@ -44,8 +44,8 @@ class Eden extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.Eden),

--- a/lib/models/rules/leagueless/leagueless.dart
+++ b/lib/models/rules/leagueless/leagueless.dart
@@ -77,8 +77,8 @@ class Leagueless extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [],
       )

--- a/lib/models/rules/north/north.dart
+++ b/lib/models/rules/north/north.dart
@@ -56,8 +56,8 @@ class North extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.North),

--- a/lib/models/rules/nucoal/nsdf.dart
+++ b/lib/models/rules/nucoal/nsdf.dart
@@ -52,6 +52,7 @@ final FactionRule ruleHighSpeedLowDrag = FactionRule(
     }
     return null;
   },
-  description: 'Veteran gears may purchase the Agile trait for 1 TV each.' +
-      ' Models with the Lumbering trait may not purchase this upgrade.',
+  description:
+      'Veteran gears may purchase the Duelist Agile trait for 1 TV each.' +
+          ' Models with the Lumbering trait may not purchase this upgrade.',
 );

--- a/lib/models/rules/nucoal/nucoal.dart
+++ b/lib/models/rules/nucoal/nucoal.dart
@@ -52,8 +52,8 @@ class NuCoal extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.NuCoal),

--- a/lib/models/rules/nucoal/pak.dart
+++ b/lib/models/rules/nucoal/pak.dart
@@ -1,4 +1,19 @@
+import 'package:gearforce/data/unit_filter.dart';
+import 'package:gearforce/models/factions/faction_rule.dart';
+import 'package:gearforce/models/factions/faction_type.dart';
+import 'package:gearforce/models/mods/factionUpgrades/nucoal.dart';
 import 'package:gearforce/models/rules/nucoal/nucoal.dart';
+import 'package:gearforce/models/rules/options/special_unit_filter.dart';
+import 'package:gearforce/models/unit/role.dart';
+import 'package:gearforce/models/unit/unit_core.dart';
+
+const String _baseRuleId = 'rule::pak';
+
+const String _ruleHoverTankCommanderId = '$_baseRuleId::10';
+const String _ruleTankJockeysId = '$_baseRuleId::20';
+const String _ruleAlliesId = '$_baseRuleId::30';
+const String _ruleAcquiredTechId = '$_baseRuleId::40';
+const String _ruleSomethingToProveId = '$_baseRuleId::50';
 
 /*
   PAK - Port Arthur Korps
@@ -21,6 +36,111 @@ class PAK extends NuCoal {
   PAK(super.data)
       : super(
           name: 'Port Arthur Korps',
-          subFactionRules: [],
+          factionRules: [
+            ruleHumanistTech,
+            FactionRule.from(
+              rulePortArthurKorps,
+              isEnabled: false,
+              requirementCheck: (_) => false,
+            )
+          ],
+          subFactionRules: [
+            ruleHoverTankCommander,
+            ruleTankJockeys,
+            ruleAllies,
+            ruleAcquiredTech,
+            ruleSomethingToProve,
+          ],
         );
 }
+
+final ruleHoverTankCommander = FactionRule(
+    name: 'Hover Tank Commander',
+    id: _ruleHoverTankCommanderId,
+    factionMod: (ur, cg, u) => NuCoalFactionMods.hoverTankCommander(),
+    description: 'Hover Tank Commander: Any commander that is in a vehicle' +
+        ' type model may improve its EW skill by one, to a maximum of 3+, for' +
+        ' 1 TV each.');
+
+final ruleTankJockeys = FactionRule(
+    name: 'Tank Jockeys',
+    id: _ruleTankJockeysId,
+    factionMod: (ur, cg, u) => NuCoalFactionMods.tankJockeys(),
+    description: 'Vehicles with the Agile trait may purchase the following' +
+        ' ability for 1 TV each: Ignore the movement penalty for traveling' +
+        ' through difficult terrain.');
+
+final ruleAllies = FactionRule(
+    name: 'Allies',
+    id: _ruleAlliesId,
+    hasGroupRole: (unit, target, group) {
+      if (!(unit.faction == FactionType.North ||
+          unit.faction == FactionType.South)) {
+        return null;
+      }
+
+      if (target == RoleType.GP ||
+          target == RoleType.SK ||
+          target == RoleType.FS ||
+          target == RoleType.RC) {
+        return true;
+      }
+      return false;
+    },
+    unitFilter: () => const SpecialUnitFilter(
+        text: 'Allies',
+        filters: [
+          UnitFilter(
+            FactionType.North,
+            matcher: matchNotAVet,
+          ),
+          UnitFilter(
+            FactionType.South,
+            matcher: matchNotAVet,
+          ),
+        ],
+        id: _ruleAlliesId),
+    description: 'This force may include gears from the North and South (may' +
+        ' include a mix) in GP, SK, FS and RC units. Models that come with' +
+        ' the Vet trait on their profile cannot be purchased. However, the' +
+        ' Vet trait may be purchased for models that do not come with it.');
+
+final ruleAcquiredTech = FactionRule(
+    name: 'Acquired Tech',
+    id: _ruleAcquiredTechId,
+    unitFilter: () => const SpecialUnitFilter(
+        text: 'Acquired Tech',
+        filters: [
+          UnitFilter(
+            FactionType.CEF,
+            matcher: _matchAcquiredTech,
+          ),
+        ],
+        id: _ruleAcquiredTechId),
+    description: 'This force may also select the following models from the' +
+        ' CEF model list: F6-16s, LHT-67s, 71s, MHT-68s, 72s, 95s, HPC-64s' +
+        ' and HC-3As.');
+
+/// Match for models for the Acquired Tech rule.
+bool _matchAcquiredTech(UnitCore uc) {
+  return _checkForAcquiredTech(uc.frame);
+}
+
+/// Check to see if a particular frame is part of the Acquired Tech rule.
+bool _checkForAcquiredTech(String frame) {
+  return frame == 'F6-16' ||
+      frame == 'LHT-67' ||
+      frame == 'LHT-71' ||
+      frame == 'MHT-68' ||
+      frame == 'MHT-72' ||
+      frame == 'MHT-95' ||
+      frame == 'HPC-64' ||
+      frame == 'HC-3A';
+}
+
+final ruleSomethingToProve = FactionRule(
+    name: 'Something to Prove',
+    id: _ruleSomethingToProveId,
+    factionMod: (ur, cg, u) => NuCoalFactionMods.somethingToProve(),
+    description:
+        'GREL infantry may increase their GU skill by one for 1 TV each.');

--- a/lib/models/rules/peace_river/peace_river.dart
+++ b/lib/models/rules/peace_river/peace_river.dart
@@ -55,8 +55,8 @@ class PeaceRiver extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.PeaceRiver),

--- a/lib/models/rules/south/south.dart
+++ b/lib/models/rules/south/south.dart
@@ -39,8 +39,8 @@ class South extends RuleSet {
   List<SpecialUnitFilter> availableUnitFilters(
     List<CombatGroupOption>? cgOptions,
   ) {
-    final coreFilter = const SpecialUnitFilter(
-      text: coreName,
+    final coreFilter = SpecialUnitFilter(
+      text: type.name,
       id: coreTag,
       filters: SouthFilters,
     );

--- a/lib/models/rules/utopia/utopia.dart
+++ b/lib/models/rules/utopia/utopia.dart
@@ -51,8 +51,8 @@ class Utopia extends RuleSet {
     List<CombatGroupOption>? cgOptions,
   ) {
     final filters = [
-      const SpecialUnitFilter(
-        text: coreName,
+      SpecialUnitFilter(
+        text: type.name,
         id: coreTag,
         filters: const [
           const UnitFilter(FactionType.Utopia),


### PR DESCRIPTION
changed the default filter from none to the name of the faction