### PR TITLE
exclude the anti-air swap mod when checking for an appropriate base weapon

### DIFF
--- a/lib/models/mods/standardUpgrades/standard_modification.dart
+++ b/lib/models/mods/standardUpgrades/standard_modification.dart
@@ -130,7 +130,10 @@ class StandardModification extends BaseModification {
           }
 
           // check to ensure the unit has an appropriate weapon that can be upgraded
-          return u.weapons.any((weapon) => weaponMatch.hasMatch(weapon.code));
+          return u
+              .attribute<List<Weapon>>(UnitAttribute.weapons,
+                  modIDToSkip: antiAirSwapId)
+              .any((w) => weaponMatch.hasMatch(w.code));
         },
         refreshData: () {
           return StandardModification.antiAirSwap(u, cg);

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -21,7 +21,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '1.2.14';
+const String _version = '1.2.15';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.2.14
+version: 1.2.15
 environment:
   sdk: ">=3.0.0"
 


### PR DESCRIPTION
when doing the requirement check for the anti-air swap mod

Found by Robear