### PR TITLE
Fixing multiple issues including ordering of brawl and sp trait adds/remove

### DIFF
--- a/lib/models/mods/mods.dart
+++ b/lib/models/mods/mods.dart
@@ -78,6 +78,30 @@ List<Trait> Function(List<Trait>) createAddTraitToList(Trait newValue) {
   };
 }
 
+/// Add the trait to the list if it does not already exist in the list.  Otherwise
+/// combine the trait with the existing trait in the list by summing the levels.
+List<Trait> Function(List<Trait>) createAddOrCombineTraitToList(
+    Trait newValue) {
+  return (value) {
+    var newList = new List<Trait>.from(value);
+
+    if (!newList.any((trait) => trait.isSameType(newValue))) {
+      newList.add(newValue);
+      return newList;
+    }
+
+    final existingTrait =
+        newList.firstWhere((trait) => trait.isSameType(newValue));
+    final newLevel = (existingTrait.level ?? 0) + (newValue.level ?? 0);
+    final index = newList.indexOf(existingTrait);
+    newList.removeAt(index);
+
+    newList.insert(index, Trait.fromTrait(existingTrait, level: newLevel));
+
+    return newList;
+  };
+}
+
 List<Weapon> Function(List<Weapon>) createAddWeaponToList(Weapon newValue) {
   return (value) {
     var newList = new List<Weapon>.from(value);

--- a/lib/models/mods/unitUpgrades/black_talon.dart
+++ b/lib/models/mods/unitUpgrades/black_talon.dart
@@ -114,7 +114,7 @@ final UnitModification darkCoyotePsi = UnitModification(name: 'Psi Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(3), description: 'TV +3')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Psi'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Comms()),
       description: '+Comms')
@@ -156,7 +156,7 @@ final UnitModification darkHoplitePsi = UnitModification(
   ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Psi'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Comms()),
       description: '+Comms')

--- a/lib/models/mods/unitUpgrades/caprice.dart
+++ b/lib/models/mods/unitUpgrades/caprice.dart
@@ -7,7 +7,7 @@ import 'package:gearforce/models/weapons/weapons.dart';
 final UnitModification command = UnitModification(name: 'Command Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(1), description: 'TV +1')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Command'))
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1');
 
 final UnitModification mortar = UnitModification(name: 'Mortar Upgrade')

--- a/lib/models/mods/unitUpgrades/north.dart
+++ b/lib/models/mods/unitUpgrades/north.dart
@@ -65,7 +65,7 @@ final UnitModification sabertooth = UnitModification(name: 'Sabertooth Upgrade')
 final UnitModification tattletale = UnitModification(name: 'Tattletale Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(1), description: 'TV +1')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Tattletale'))
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: 'SP:1');
 
 final UnitModification mpCommand = UnitModification(name: 'Command Upgrade')

--- a/lib/models/mods/unitUpgrades/peace_river.dart
+++ b/lib/models/mods/unitUpgrades/peace_river.dart
@@ -116,7 +116,7 @@ final UnitModification greyhoundChieftain =
       ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
       ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Chieftain'))
       ..addMod(UnitAttribute.ew, createSetIntMod(3), description: 'EW 3+')
-      ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+      ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
           description: '+SP:+1')
       ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.ECCM()),
           description: '+ECCM');
@@ -155,7 +155,7 @@ final UnitModification shinobiMeleeSpecialist = UnitModification(
     name: 'Melee Specialist Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(1), description: 'TV: +1')
   ..addMod(UnitAttribute.name, createSimpleStringMod(false, 'melee specialist'))
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Brawl(2)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.Brawl(2)),
       description: '+Brawl:2')
   ..addMod(
       UnitAttribute.weapons,
@@ -227,7 +227,7 @@ final UnitModification cataphractLord = UnitModification(name: 'Lord Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Lord'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Comms()),
       description: '+Comms')
@@ -249,7 +249,7 @@ final UnitModification uhlanLord = UnitModification(name: 'Lord Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Lord'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Comms()),
       description: '+Comms')
@@ -268,7 +268,7 @@ final UnitModification alphaDog = UnitModification(name: 'Alpha Dog Upgrade')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(3), description: 'TV +3')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Alpha Dog'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.ECCM()),
       description: '+ECCM')
@@ -295,7 +295,7 @@ final UnitModification herdLord = UnitModification(
   ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
   ..addMod(UnitAttribute.name, createSimpleStringMod(true, 'Herd Lord'))
   ..addMod(UnitAttribute.ew, createSetIntMod(4), description: 'EW 4+')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.SP(1)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.SP(1)),
       description: '+SP:+1')
   ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Comms()),
       description: '+Comms')

--- a/lib/models/mods/unitUpgrades/south.dart
+++ b/lib/models/mods/unitUpgrades/south.dart
@@ -148,7 +148,8 @@ UnitModification diamondbackArenaPilot(Unit u) {
 
       return newList;
     }, description: '+LVB (Precise) or +LCW (Brawl:1)')
-    ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Brawl(1)),
+    ..addMod(
+        UnitAttribute.traits, createAddOrCombineTraitToList(Trait.Brawl(1)),
         description: '+Brawl:1');
 }
 
@@ -159,7 +160,7 @@ final UnitModification blackAdderArenaPilot = UnitModification(
   ..addMod(UnitAttribute.weapons,
       createAddWeaponToList(buildWeapon('MVB (Reach:1)', hasReact: true)!),
       description: '+MVB (Reach:1)')
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Brawl(2)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.Brawl(2)),
       description: '+Brawl:2');
 
 final UnitModification cobraRazorFang =
@@ -218,7 +219,7 @@ final UnitModification meleeSwap = UnitModification(
 final UnitModification boasArenaPilot = UnitModification(name: 'Arena Pilot')
   ..addMod(UnitAttribute.tv, createSimpleIntMod(1), description: 'TV: +1')
   ..addMod(UnitAttribute.name, createSimpleStringMod(false, 'with Arena Pilot'))
-  ..addMod(UnitAttribute.traits, createAddTraitToList(Trait.Brawl(2)),
+  ..addMod(UnitAttribute.traits, createAddOrCombineTraitToList(Trait.Brawl(2)),
       description: '+Brawl:2');
 
 final UnitModification barbed = UnitModification(

--- a/lib/models/mods/veteranUpgrades/veteran_modification.dart
+++ b/lib/models/mods/veteranUpgrades/veteran_modification.dart
@@ -280,7 +280,6 @@ class VeteranModification extends BaseModification {
     final modName = _vetModNames[brawler1Id];
     assert(modName != null);
 
-    final traits = u.traits.toList();
     return VeteranModification(
         name: modName ?? brawler1Id,
         id: brawler1Id,
@@ -301,18 +300,9 @@ class VeteranModification extends BaseModification {
           return rs!.veteranModCheck(u, cg!, modID: brawler1Id);
         })
       ..addMod(UnitAttribute.tv, createSimpleIntMod(1), description: 'TV +1')
-      ..addMod<List<Trait>>(UnitAttribute.traits, (value) {
-        var newLevel = 0;
-        if (traits.any((element) => element.name == 'Brawl')) {
-          var oldTrait =
-              traits.firstWhere((element) => element.name == 'Brawl');
-          newLevel = oldTrait.level == null ? 1 : oldTrait.level!;
-          value = createRemoveTraitFromList(oldTrait)(value);
-        }
-
-        return createAddTraitToList(Trait(name: 'Brawl', level: newLevel + 1))(
-            value);
-      }, description: '+Brawl:1 or +1 to existing Brawl');
+      ..addMod<List<Trait>>(UnitAttribute.traits,
+          createAddOrCombineTraitToList(Trait(name: 'Brawl', level: 1)),
+          description: '+Brawl:1 or +1 to existing Brawl');
   }
 
   /*
@@ -325,7 +315,6 @@ class VeteranModification extends BaseModification {
     final modName = _vetModNames[brawler2Id];
     assert(modName != null);
 
-    final traits = u.traits.toList();
     return VeteranModification(
         name: modName ?? brawler2Id,
         id: brawler2Id,
@@ -349,18 +338,9 @@ class VeteranModification extends BaseModification {
           return VeteranModification.brawler2(u);
         })
       ..addMod(UnitAttribute.tv, createSimpleIntMod(2), description: 'TV +2')
-      ..addMod<List<Trait>>(UnitAttribute.traits, (value) {
-        var newLevel = 0;
-        if (traits.any((element) => element.name == 'Brawl')) {
-          var oldTrait =
-              traits.firstWhere((element) => element.name == 'Brawl');
-          newLevel = oldTrait.level == null ? 0 : oldTrait.level!;
-          value = createRemoveTraitFromList(oldTrait)(value);
-        }
-
-        return createAddTraitToList(Trait(name: 'Brawl', level: newLevel + 2))(
-            value);
-      }, description: '+Brawl:2 or +2 to existing Brawl');
+      ..addMod<List<Trait>>(UnitAttribute.traits,
+          createAddOrCombineTraitToList(Trait(name: 'Brawl', level: 2)),
+          description: '+Brawl:2 or +2 to existing Brawl');
   }
 
   /*

--- a/lib/models/unit/unit.dart
+++ b/lib/models/unit/unit.dart
@@ -456,10 +456,6 @@ class Unit extends ChangeNotifier {
   }
 
   int get skillPoints {
-    if (commandLevel != CommandLevel.none) {
-      return 0;
-    }
-
     return _calculateSkillPoints();
   }
 
@@ -469,6 +465,11 @@ class Unit extends ChangeNotifier {
     for (var mod in this._mods) {
       sp = mod.applyMods(UnitAttribute.sp, sp);
     }
+
+    final numSPMods =
+        traits.where((trait) => trait.isSameType(Trait.SP(0))).length;
+
+    sp += numSPMods;
 
     if (isVeteran) {
       sp += 1;

--- a/lib/models/unit/unit.dart
+++ b/lib/models/unit/unit.dart
@@ -93,7 +93,7 @@ class Unit extends ChangeNotifier {
       mods.forEach((loadedMod) {
         try {
           var mod = availableUnitMods
-              .firstWhere((unitMod) => unitMod.name == loadedMod['id']);
+              .firstWhere((unitMod) => unitMod.id == loadedMod['id']);
           u.addUnitMod(mod);
           final selected = loadedMod['selected'];
           if (selected != null) {
@@ -172,17 +172,21 @@ class Unit extends ChangeNotifier {
       final mods = modMap['faction'] as List;
 
       mods.forEach((loadedMod) {
-        final modId = loadedMod['id'];
+        try {
+          final modId = loadedMod['id'];
 
-        var mod = factionModFromId(modId, roster, u);
-        if (mod == null) {
-          print('faction mod $modId could not be loaded');
-          return;
-        }
-        u.addUnitMod(mod);
-        final selected = loadedMod['selected'];
-        if (selected != null) {
-          modsWithOptions[mod] = selected;
+          var mod = factionModFromId(modId, roster, u);
+          if (mod == null) {
+            print('faction mod $modId could not be loaded');
+            return;
+          }
+          u.addUnitMod(mod);
+          final selected = loadedMod['selected'];
+          if (selected != null) {
+            modsWithOptions[mod] = selected;
+          }
+        } catch (e) {
+          print('faction mod $loadedMod not found in available mods, $e');
         }
       });
     }

--- a/lib/models/unit/unit_core.dart
+++ b/lib/models/unit/unit_core.dart
@@ -102,7 +102,7 @@ class UnitCore {
         return 0;
       case UnitAttribute.sp:
         var value = 0;
-        traits.where((t) => t.name == "SP").forEach((t) {
+        traits.where((t) => t.isSameType(Trait.SP(0))).forEach((t) {
           value += t.level ?? 0;
         });
         return value;

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -21,7 +21,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '1.2.16';
+const String _version = '1.2.17';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.2.16
+version: 1.2.17
 environment:
   sdk: ">=3.0.0"
 


### PR DESCRIPTION
* Removing an upgrade after adding the vet brawl upgrade that has brawl will result in the correct brawl value
* Same issue would affect SP.  issue is fixed for SP as well.
* When loading unit mods, check against the mod id not the mod name
All issues found by Robear