### PR TITLE
Removed extra spaces in several units names,

### DIFF
--- a/assets/data/units/north.json
+++ b/assets/data/units/north.json
@@ -1327,7 +1327,7 @@
       ]
     },
     {
-      "name": "Black  Cat",
+      "name": "Black Cat",
       "variants": [
         {
           "model": "Black Cat",

--- a/assets/data/units/utopia.json
+++ b/assets/data/units/utopia.json
@@ -60,7 +60,7 @@
       "name": "Commando N-KIDU",
       "variants": [
         {
-          "model": "Commando  N-KIDU",
+          "model": "Commando N-KIDU",
           "tv": 6,
           "role": "GP+, SK, SO",
           "mr": "H:8",
@@ -77,7 +77,7 @@
           "height": 1.5
         },
         {
-          "model": "ECM Commando  N-KIDU",
+          "model": "ECM Commando N-KIDU",
           "tv": 7,
           "role": "GP, SK, SO",
           "mr": "H:8",
@@ -94,7 +94,7 @@
           "height": 1.5
         },
         {
-          "model": "EMT Commando  N-KIDU",
+          "model": "EMT Commando N-KIDU",
           "tv": 6,
           "role": "GP, SK, SO",
           "mr": "H:8",
@@ -189,7 +189,7 @@
       "name": "Recce N-KIDU",
       "variants": [
         {
-          "model": "Recce  N-KIDU",
+          "model": "Recce N-KIDU",
           "tv": 4,
           "role": "GP+, RC, FS",
           "mr": "W:6",
@@ -206,7 +206,7 @@
           "height": 1
         },
         {
-          "model": "Hunter Recce  N-KIDU",
+          "model": "Hunter Recce N-KIDU",
           "tv": 4,
           "role": "GP+, RC, FS",
           "mr": "W:6",
@@ -223,7 +223,7 @@
           "height": 1
         },
         {
-          "model": "MP Recce  N-KIDU",
+          "model": "MP Recce N-KIDU",
           "tv": 4,
           "role": "GP+, RC, FS",
           "mr": "W:6",
@@ -240,7 +240,7 @@
           "height": 1
         },
         {
-          "model": "ECM Recce  N-KIDU",
+          "model": "ECM Recce N-KIDU",
           "tv": 4,
           "role": "GP+, RC, FS",
           "mr": "W:6",
@@ -257,7 +257,7 @@
           "height": 1
         },
         {
-          "model": "Pazu-Recce  N-KIDU*",
+          "model": "Pazu-Recce N-KIDU*",
           "tv": 5,
           "role": "GP+, RC, FS",
           "mr": "W:6",
@@ -318,7 +318,7 @@
       "name": "Support N-KIDU",
       "variants": [
         {
-          "model": "Support  N-KIDU",
+          "model": "Support N-KIDU",
           "tv": 5,
           "role": "GP, SK, FS",
           "mr": "G:6",
@@ -335,7 +335,7 @@
           "height": 1
         },
         {
-          "model": "Missile Support  N-KIDU",
+          "model": "Missile Support N-KIDU",
           "tv": 7,
           "role": "GP, SK, FS",
           "mr": "G:6",
@@ -352,7 +352,7 @@
           "height": 1
         },
         {
-          "model": "Mortar Support  N-KIDU",
+          "model": "Mortar Support N-KIDU",
           "tv": 5,
           "role": "GP, SK, FS",
           "mr": "G:6",
@@ -369,7 +369,7 @@
           "height": 1
         },
         {
-          "model": "Pazu-Support  N-KIDU*",
+          "model": "Pazu-Support N-KIDU*",
           "tv": 7,
           "role": "GP, SK, FS",
           "mr": "G:6",
@@ -481,7 +481,7 @@
           "height": 1
         },
         {
-          "model": "Gunner Support  APE",
+          "model": "Gunner Support APE",
           "tv": 8,
           "role": "GP, SK, FS",
           "mr": "W:6",
@@ -515,7 +515,7 @@
           "height": 1
         },
         {
-          "model": "Fire Support  APE",
+          "model": "Fire Support APE",
           "tv": 8,
           "role": "GP, SK, FS",
           "mr": "W:6",
@@ -532,7 +532,7 @@
           "height": 1
         },
         {
-          "model": "Bazooka Support  APE",
+          "model": "Bazooka Support APE",
           "tv": 8,
           "role": "GP, SK, FS",
           "mr": "W:6",

--- a/lib/models/mods/duelist/duelist_modification.dart
+++ b/lib/models/mods/duelist/duelist_modification.dart
@@ -400,9 +400,11 @@ class DuelistModification extends BaseModification {
         if (modOptions.selectedOption != null &&
             newList.any((weapon) =>
                 weapon.toString() == modOptions.selectedOption?.text)) {
-          var existingWeapon = newList.firstWhere(
+          final existingWeapon = newList.firstWhere(
               (weapon) => weapon.toString() == modOptions.selectedOption?.text);
-          existingWeapon.bonusTraits.add(traitToAdd);
+          final index = newList.indexOf(existingWeapon);
+          newList[index] =
+              Weapon.fromWeapon(existingWeapon, addTraits: [traitToAdd]);
         }
         return newList;
       });

--- a/lib/models/unit/unit.dart
+++ b/lib/models/unit/unit.dart
@@ -699,7 +699,7 @@ class Unit extends ChangeNotifier {
 
   @override
   String toString() {
-    return 'Unit: $name, TV: $tv, Rank: ${commandLevel.name}, Mods: $modNames';
+    return 'Unit: $name, Hash: $hashCode, TV: $tv, Rank: ${commandLevel.name}, Mods: $modNames';
   }
 }
 

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -21,7 +21,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '1.3.0';
+const String _version = '1.3.1';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';

--- a/lib/screens/upgrades/unit_upgrade_button.dart
+++ b/lib/screens/upgrades/unit_upgrade_button.dart
@@ -69,6 +69,7 @@ void showUnitUpgradeDialog(
       print('         mods: ${unit.modNames.toString()}');
       print('      actions: ${unit.actions}');
       print('           tv: ${unit.tv}');
+      print('         hash: ${unit.hashCode}');
     }
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.3.0
+version: 1.3.1
 environment:
   sdk: ">=3.0.0"
 


### PR DESCRIPTION
the precise duelist upgrade now creates a copy of the weapon it is adding precise to instead of modifying the shared weapon found by Robear