### PR TITLE
Get the app version from the pubspec file as a single source of truth

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,10 @@ import 'package:gearforce/data/data.dart';
 import 'package:gearforce/screens/roster/roster.dart';
 import 'package:gearforce/widgets/roster_id.dart';
 import 'package:gearforce/widgets/settings.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   //final myUrl = Uri.base.toString();
 
@@ -15,6 +16,8 @@ void main() {
     print('loading id: $idParam');
   }
 
+  final appInfo = await PackageInfo.fromPlatform();
+
   var data = Data();
   data.load().whenComplete(() {
     runApp(MultiProvider(
@@ -22,7 +25,11 @@ void main() {
         Provider(create: (_) => data),
         Provider(create: (_) => Settings()),
       ],
-      child: GearForce(data: data, rosterId: RosterId(idParam)),
+      child: GearForce(
+        data: data,
+        rosterId: RosterId(idParam),
+        version: appInfo.version,
+      ),
     ));
   });
 }
@@ -32,10 +39,12 @@ class GearForce extends StatefulWidget {
     Key? key,
     required this.data,
     required this.rosterId,
+    required this.version,
   }) : super(key: key);
 
   final Data data;
   final RosterId rosterId;
+  final String version;
   @override
   _GearForceState createState() => _GearForceState();
 }
@@ -59,6 +68,7 @@ class _GearForceState extends State<GearForce> {
         title: 'Gearforce',
         data: widget.data,
         rosterId: widget.rosterId,
+        version: widget.version,
       ),
     );
   }

--- a/lib/screens/roster/roster.dart
+++ b/lib/screens/roster/roster.dart
@@ -21,7 +21,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 const double _leftPanelWidth = 670.0;
 const double _titleHeight = 40.0;
 const double _menuTitleHeight = 50.0;
-const String _version = '1.6.1';
+// const String version = '1.6.1';
 const String _bugEmailAddress = 'gearforce@metadiversions.com';
 const String _dp9URL = 'https://www.dp9.com/';
 const String _sourceCodeURL = 'https://github.com/Ariemeth/gearforce-flutter';
@@ -32,11 +32,13 @@ class RosterWidget extends StatefulWidget {
     required this.title,
     required this.data,
     required this.rosterId,
+    required this.version,
   }) : super(key: key);
 
   final String? title;
   final Data data;
   final RosterId rosterId;
+  final String version;
   final hScrollController = ScrollController();
 
   @override
@@ -192,7 +194,7 @@ class _RosterWidgetState extends State<RosterWidget> {
                 );
 
                 if (pdfSettings != null) {
-                  printPDF(roster, pdfSettings, version: _version);
+                  printPDF(roster, pdfSettings, version: widget.version);
                 }
               },
             ),
@@ -208,7 +210,7 @@ class _RosterWidgetState extends State<RosterWidget> {
                 );
 
                 if (pdfSettings != null) {
-                  downloadPDF(roster, pdfSettings, version: _version);
+                  downloadPDF(roster, pdfSettings, version: widget.version);
                 }
               },
             ),
@@ -241,7 +243,7 @@ class _RosterWidgetState extends State<RosterWidget> {
             ),
             AboutListTile(
               applicationName: 'Gearforce',
-              applicationVersion: _version,
+              applicationVersion: widget.version,
               aboutBoxChildren: [
                 Text('Gearforce is a Heavy Gear Blitz force creation tool'),
                 RichText(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,13 @@ import FlutterMacOS
 import Foundation
 
 import file_selector_macos
+import package_info_plus
 import printing
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -392,6 +392,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
@@ -625,10 +641,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
+      sha256: "6ce1e04375be4eed30548f10a315826fd933c1e493206eab82eed01f438c8d2e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.5"
+    version: "6.2.6"
   url_launcher_android:
     dependency: transitive
     description:
@@ -689,10 +705,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -741,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.6.1
+version: 1.6.2
 environment:
   sdk: ">=3.0.0"
 
@@ -26,14 +26,15 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.4
+  cupertino_icons: 1.0.8
   provider: 6.1.2
-  uuid: 4.3.3
+  uuid: 4.4.0
   pdf: 3.10.8
   printing: 5.12.0
-  url_launcher: 6.2.5
+  url_launcher: 6.2.6
   file_selector: 1.0.3
   http: 1.2.1
+  package_info_plus: 8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Using package_info_plus to pull the current version from the pubspec file

instead of needing to have to places for the version to live