### PR TITLE
Fixing faction selector not selectable when first loaded

### DIFF
--- a/lib/v3/data/data.dart
+++ b/lib/v3/data/data.dart
@@ -159,6 +159,20 @@ class DataV3 {
     ];
   }
 
+  static List<FactionType> getFactionTypes() {
+    return [
+      FactionType.blackTalon,
+      FactionType.cef,
+      FactionType.caprice,
+      FactionType.eden,
+      FactionType.north,
+      FactionType.nuCoal,
+      FactionType.peaceRiver,
+      FactionType.south,
+      FactionType.utopia,
+    ];
+  }
+
   Future<List<Frame>> _loadFrames(
     String filename, {
     required FactionType faction,

--- a/lib/v3/screens/roster/header/select_faction.dart
+++ b/lib/v3/screens/roster/header/select_faction.dart
@@ -26,7 +26,7 @@ class _SelectFactionState extends State<SelectFaction> {
   Widget build(BuildContext context) {
     final data = context.watch<DataV3>();
     final settings = context.watch<Settings>();
-    return DropdownButton<FactionType?>(
+    final dropdown = DropdownButton<FactionType>(
       value: widget.selectedFaction.value.factionType,
       hint: const Text('Select faction'),
       icon: const Icon(Icons.arrow_downward),
@@ -46,16 +46,27 @@ class _SelectFactionState extends State<SelectFaction> {
           );
         });
       },
-      items:
-          widget.factions.map<DropdownMenuItem<FactionType>>((Faction value) {
-        return DropdownMenuItem<FactionType>(
-          value: value.factionType,
-          child: Text(
-            value.factionType.name,
-            style: const TextStyle(fontSize: 16),
-          ),
-        );
-      }).toList(),
+      items: _factions(),
     );
+
+    return dropdown;
+  }
+
+  List<DropdownMenuItem<FactionType>> _factions() {
+    final factions = DataV3.getFactionTypes();
+
+    final List<DropdownMenuItem<FactionType>> menuItems = [];
+
+    for (var value in factions) {
+      menuItems.add(DropdownMenuItem<FactionType>(
+        value: value,
+        child: Text(
+          value.name,
+          style: const TextStyle(fontSize: 16),
+        ),
+      ));
+    }
+
+    return menuItems;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.16.5
+version: 1.16.6
 environment:
   sdk: ">=3.0.0"
 


### PR DESCRIPTION
Found by Balance

When loading Gearforce the faction selector is empty and not selectable.  Sub-List is selectable and property defaulting to Black Talon.  Once a sub-list is selected the faction selector is populated and works fine.